### PR TITLE
Add the research question answer box command  

### DIFF
--- a/chapters/X_chapter.tex
+++ b/chapters/X_chapter.tex
@@ -139,6 +139,10 @@ Long dash : --- \\
     \item[--] Hightlight 4
 \end{itemize}
 }
+
+\subsection{Research question answer box}
+\answer[H]{RQ1}{My research question?}{\lipsum[25]}
+
 \newpage
 
 %%% ENUMERATIONS %%%

--- a/style/umemoir.cls
+++ b/style/umemoir.cls
@@ -559,3 +559,18 @@ Dépôt légal: % TODO
  \textbf{#2}}
 \end{flushright}
 }
+
+% %%% Research question text boxes %%%
+% Example usage : \answer{RQ.x}{Research question?}{This is an answer.}
+
+\newcommand{\answer}[4][H]{
+\begin{figure}[#1]
+        \centering
+    \resizebox{\textwidth}{!}{%  
+    \begin{tikzpicture}
+        \node[anchor=text,text width=\columnwidth-0.2cm, draw, rounded corners, line width=0.5pt, fill=unamur_grey!5!white, inner sep=3mm, align=justify] (big) {\begin{flushright}\small #3\end{flushright}\vspace{2mm} #4};
+        \node[draw, rounded corners, line width=0.5pt, fill=black, anchor=west, xshift=4mm, ,scale=1.1] (small) at (big.north west) {\text{  }\bfseries{\textbf{\textcolor{white}{#2}}}\text{  }};
+    \end{tikzpicture}
+    }%
+\end{figure}
+}


### PR DESCRIPTION
Add a new command to the template: `\answer[position]{id}{rq}{answer}`. 

# Example 
```latex
\answer[H]{RQ1}{My research question?}{\lipsum[25]}
```
<img width="637" height="329" alt="Capture d’écran 2025-10-31 à 11 00 41" src="https://github.com/user-attachments/assets/11c1d202-6056-405c-90e2-1e27dcc7cf54" />

Thanks @Jefidev for the template. 
