### PR TITLE
Add GitHub Action for automatic PDF build and FTP publishing

### DIFF
--- a/.github/workflows/latex-ftp.yml
+++ b/.github/workflows/latex-ftp.yml
@@ -1,0 +1,73 @@
+name: Build LaTeX and Upload PDF to FTP
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/xu-cheng/texlive-alpine:latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Install extra packages
+        run: apk add --no-cache curl nodejs
+
+      - name: Compile main.tex
+        run: |
+          set -eu
+          TEX="pdflatex -synctex=1 -interaction=nonstopmode -file-line-error main.tex"
+          $TEX              # 1st pass  - generate .aux, .idx, .glo, .acn
+          bibtex main || true   # build bibliography (.bbl)
+          makeglossaries main   # build glossary + acronyms (.gls, .acr)
+          $TEX              # 2nd pass  - incorporate bib/glossary
+          $TEX              # 3rd pass  - resolve all cross-references
+
+      - name: Verify PDF output exists
+        run: test -f main.pdf
+
+      - name: Compute versioned filename
+        id: version
+        run: |
+          SHORT_SHA="$(echo "$GITHUB_SHA" | cut -c1-7)"
+          TIMESTAMP="$(date -u +'%Y%m%d-%H%M%S')"
+          echo "filename=main-${TIMESTAMP}-${GITHUB_RUN_NUMBER}-${SHORT_SHA}.pdf" >> "$GITHUB_OUTPUT"
+
+      - name: Upload versioned and latest PDFs to FTP
+        if: ${{ env.FTP_HOST != '' }}
+        env:
+          FTP_HOST: ${{ secrets.FTP_HOST }}
+          FTP_USER: ${{ secrets.FTP_USER }}
+          FTP_PWD: ${{ secrets.FTP_PWD }}
+          FTP_PORT: ${{ secrets.FTP_PORT }}
+          VERSIONED_FILENAME: ${{ steps.version.outputs.filename }}
+        run: |
+          set -eu
+
+          FTP_BASE_URL="ftp://${FTP_HOST}:${FTP_PORT}"
+
+          # 1) Upload immutable versioned file to versions/
+          curl --fail --show-error --silent \
+            --ftp-create-dirs \
+            --user "${FTP_USER}:${FTP_PWD}" \
+            -T "main.pdf" \
+            "${FTP_BASE_URL}/versions/${VERSIONED_FILENAME}"
+
+          # 2) Upload/update latest file in current/
+          curl --fail --show-error --silent \
+            --ftp-create-dirs \
+            --user "${FTP_USER}:${FTP_PWD}" \
+            -T "main.pdf" \
+            "${FTP_BASE_URL}/current/latest.pdf"
+
+      - name: Upload build artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: thesis-pdf
+          path: main.pdf

--- a/README.md
+++ b/README.md
@@ -111,6 +111,50 @@ When you want to update the template to the latest version, run the following co
 git submodule update --remote --merge ThesisTemplate
 ```
 
+## GitHub Action for Automatic PDF Build and FTP Publish
+
+This template provides a GitHub Action workflow to compile `main.tex` and publish the generated PDF to an FTP server with:
+
+* a versioned file in `versions/`
+* a rolling latest file in `current/latest.pdf`
+
+Important: if you use this template as a git submodule, workflows stored inside `ThesisTemplate/.github/workflows/` are not executed automatically by GitHub for your thesis repository.
+
+To enable the workflow in your own thesis repository:
+
+1. Copy the workflow file from the template to your repository root workflow folder:
+
+```bash
+mkdir -p .github/workflows
+cp ThesisTemplate/.github/workflows/latex-ftp.yml .github/workflows/
+```
+
+2. Add the following repository secrets in your thesis repository:
+  * `FTP_HOST` (ex. `ftp.unamur.be`)
+  * `FTP_USER` (ex. `myusername`)
+  * `FTP_PWD` (ex. `mypassword`)
+  * `FTP_PORT` (ex. `21`)
+
+3. Commit and push the workflow file from your thesis repository.
+
+By default, the workflow is configured for manual execution (`workflow_dispatch`).
+You can run it from GitHub: **Actions** -> **Build LaTeX and Upload PDF to FTP** -> **Run workflow**.
+
+If you want automatic execution on each push, add or keep a `push` trigger in the workflow `on:` section.
+For example:
+```yaml
+name: Build LaTeX and Upload PDF to FTP
+
+on:
+  push:
+  workflow_dispatch:
+...
+```
+
+ > Note that Github Action are paid services, but they offer a free tier with a certain amount of free minutes per month (2000 minutes). If you exceed this limit, you may need to pay for additional minutes. However, for a typical thesis project, the free tier should be sufficient for most users.
+
+4. The workflow is [act](https://github.com/nektos/act) compatible, so you can also run it locally for testing before pushing to GitHub
+
 ## Frequently Asked Questions
 
 * *Once I've finished my thesis, what should I do?*


### PR DESCRIPTION
This pull request proposes a CI/CD pipeline for building the main.tex document and uploading the resulting PDF to an FTP server.

The rationale behind this approach is to avoid storing the main.pdf file within the version control system, as it is not well-suited for Git. Nevertheless, it remains important to provide easy access to previous versions of the manuscript in PDF format, rather than requiring users to check out and build each version.

Additionally, the action not only uploads the new version to a `versions/ `directory but also updates (overwrites) a `latest.pdf` document. This ensures that the same link can be shared with your supervisor, guaranteeing that they have access to the most recent (uploaded) version.

Here is a more detailled user guide and setup instructions.

By default, the action is set to "on demand" only, to prevent unnecessary triggers in this repository. However, the README has been updated to recommend enabling an automated trigger.


---

## 1. What this setup does

On every push:

1. GitHub Actions checks out the repository (with submodules).
2. The LaTeX document is compiled (`pdflatex`, `bibtex`, `makeglossaries`, `pdflatex`, `pdflatex`).
3. `main.pdf` is uploaded to FTP twice:
   - immutable versioned file: `versions/main-YYYYMMDD-HHMMSS-RUNNUMBER-SHORTSHA.pdf`
   - rolling latest file: `current/latest.pdf`
4. The PDF is also uploaded as a GitHub Actions artifact (on GitHub runners only).

---

## 2. Required repository secrets

In your GitHub repository:

Settings -> Secrets and variables -> Actions -> New repository secret

Create these 4 secrets:

- `FTP_HOST` (example: `ftp.example.com`)
- `FTP_USER`
- `FTP_PWD`
- `FTP_PORT` (example: `21`)

Notes:

- `FTP_HOST` must be only the host name or IP, without protocol prefix.
- `FTP_PORT` must be the FTP port as a string.

---

## 3. Expected FTP folder structure

The workflow creates directories automatically if needed:

- `versions/`
- `current/`

After a run, you should see:

- `versions/main-...pdf` (new file each run)
- `current/latest.pdf` (overwritten each run)

---

## 4. Workflow file location

The workflow file stored at `.github/workflows/latex-ftp.yml`:


Current behavior:

- trigger: push + manual workflow dispatch
- container: `ghcr.io/xu-cheng/texlive-alpine:latest`
- checkout action: `actions/checkout@v6.0.2`
- artifact action: `actions/upload-artifact@v7.0.0` (skipped in `act` runs)

---

## 5. Why this does not store PDFs in Git

Generated PDFs are build artifacts and deployment outputs. They are published to FTP, not committed to the repository.

Recommended:

- keep `main.pdf` and build intermediates ignored in `.gitignore`
- treat FTP as output storage for generated documents

---

## 6. Local testing with act (optional)

This project supports local workflow testing with `act`.

### 6.1 Recommended act config

Create `.actrc` at repo root:

```txt
--use-new-action-cache
```

### 6.2 Provide local secret equivalents

Either export env vars/secrets for `act`, or use an `.env`/secrets file supported by your local setup.

### 6.3 Important behavior differences in act

- `actions/upload-artifact` may fail in local `act` runs without full GitHub runtime services.
- In this project, artifact upload is skipped when running under `act`.
- FTP upload can still be fully tested locally.

---

## 7. Security notes

- Never hardcode FTP credentials in workflow YAML.
- Always use GitHub repository secrets.
- Consider switching to FTPS/SFTP if your server supports it.

---

## 8. Verification checklist

After pushing a commit:

1. Workflow succeeds in GitHub Actions.
2. `main.pdf` is generated in the job (step `actions/upload-artifact`).
3. A new file appears in FTP `versions/`.
4. FTP `current/latest.pdf` is updated.
5. No generated PDF is committed to Git.

If all 5 checks pass, your setup is complete.



 > Side Note: This pull request also paves the way for automated testing in future pull requests and ensures that updates do not disrupt the compilation of the template.